### PR TITLE
Fixed walletpassphrase form RPC

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -890,20 +890,6 @@ void RPCRunHandler(const boost::system::error_code& err, boost::function<void(vo
         func();
 }
 
-void RPCRunLater(const std::string& name, boost::function<void(void)> func, int64 nSeconds)
-{
-    assert(rpc_io_service != NULL);
-
-    if (deadlineTimers.count(name) == 0)
-    {
-        deadlineTimers.insert(make_pair(name,
-                                        boost::shared_ptr<deadline_timer>(new deadline_timer(*rpc_io_service))));
-    }
-    deadlineTimers[name]->expires_from_now(posix_time::seconds(nSeconds));
-    deadlineTimers[name]->async_wait(boost::bind(RPCRunHandler, _1, func));
-}
-
-
 class JSONRequest
 {
 public:

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -9,7 +9,7 @@
 #define CLIENT_VERSION_MAJOR       0
 #define CLIENT_VERSION_MINOR       8
 #define CLIENT_VERSION_REVISION    99
-#define CLIENT_VERSION_BUILD       11
+#define CLIENT_VERSION_BUILD       12
 
 // Set to true for release, false for prerelease or test build
 #define CLIENT_VERSION_IS_RELEASE  true

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -71,7 +71,9 @@ Value importprivkey(const Array& params, bool fHelp)
         throw runtime_error(
             "importprivkey <zetacoinprivkey> [label] [rescan=true]\n"
             "Adds a private key (as returned by dumpprivkey) to your wallet.");
-
+    
+    EnsureWalletIsUnlocked();
+    
     string strSecret = params[0].get_str();
     string strLabel = "";
     if (params.size() > 1)
@@ -88,6 +90,8 @@ Value importprivkey(const Array& params, bool fHelp)
     if (!fGood) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
 
     CKey key = vchSecret.GetKey();
+    if (!key.IsValid()) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key outside allowed range");
+    
     CPubKey pubkey = key.GetPubKey();
     CKeyID vchAddress = pubkey.GetID();
     {

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1269,12 +1269,56 @@ Value keypoolrefill(const Array& params, bool fHelp)
     return Value::null;
 }
 
-
-static void LockWallet(CWallet* pWallet)
+void ThreadTopUpKeyPool(void* parg)
 {
-    LOCK(cs_nWalletUnlockTime);
-    nWalletUnlockTime = 0;
-    pWallet->Lock();
+    // Make this thread recognisable as the key-topping-up thread
+    RenameThread("bitcoin-key-top");
+
+    pwalletMain->TopUpKeyPool();
+}
+
+void ThreadCleanWalletPassphrase(void* parg)
+{
+    // Make this thread recognisable as the wallet relocking thread
+    RenameThread("bitcoin-lock-wa");
+
+    int64 nMyWakeTime = GetTimeMillis() + *((int64*)parg) * 1000;
+
+    ENTER_CRITICAL_SECTION(cs_nWalletUnlockTime);
+
+    if (nWalletUnlockTime == 0)
+    {
+        nWalletUnlockTime = nMyWakeTime;
+
+        do
+        {
+            if (nWalletUnlockTime==0)
+                break;
+            int64 nToSleep = nWalletUnlockTime - GetTimeMillis();
+            if (nToSleep <= 0)
+                break;
+
+            LEAVE_CRITICAL_SECTION(cs_nWalletUnlockTime);
+            MilliSleep(nToSleep);
+            ENTER_CRITICAL_SECTION(cs_nWalletUnlockTime);
+
+        } while(1);
+
+        if (nWalletUnlockTime)
+        {
+            nWalletUnlockTime = 0;
+            pwalletMain->Lock();
+        }
+    }
+    else
+    {
+        if (nWalletUnlockTime < nMyWakeTime)
+            nWalletUnlockTime = nMyWakeTime;
+    }
+
+    LEAVE_CRITICAL_SECTION(cs_nWalletUnlockTime);
+
+    delete (int64*)parg;
 }
 
 Value walletpassphrase(const Array& params, bool fHelp)
@@ -1305,12 +1349,9 @@ Value walletpassphrase(const Array& params, bool fHelp)
             "walletpassphrase <passphrase> <timeout>\n"
             "Stores the wallet decryption key in memory for <timeout> seconds.");
 
-    pwalletMain->TopUpKeyPool();
-
-    int64 nSleepTime = params[1].get_int64();
-    LOCK(cs_nWalletUnlockTime);
-    nWalletUnlockTime = GetTime() + nSleepTime;
-    RPCRunLater("lockwallet", boost::bind(LockWallet, pwalletMain), nSleepTime);
+    NewThread(ThreadTopUpKeyPool, NULL);
+    int64* pnSleepTime = new int64(params[1].get_int64());
+    NewThread(ThreadCleanWalletPassphrase, pnSleepTime);
 
     return Value::null;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1468,3 +1468,15 @@ void RenameThread(const char* name)
     (void)name;
 #endif
 }
+
+bool NewThread(void(*pfn)(void*), void* parg)
+{
+    try
+    {
+        boost::thread(pfn, parg); // thread detaches when out of scope
+    } catch(boost::thread_resource_error &e) {
+        printf("Error creating thread: %s\n", e.what());
+        return false;
+    }
+    return true;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -492,6 +492,8 @@ public:
     }
 };
 
+bool NewThread(void(*pfn)(void*), void* parg);
+
 #ifdef WIN32
 inline void SetThreadPriority(int nPriority)
 {


### PR DESCRIPTION
In debug windows, the command "walletpassphrase" cause the crash of zetacoin-qt.

Now start a new thread and works without problem.

RPCRunLater() is never used
LockWallet() is never used

Update the CLIENT_VERSION_BUILD to 12
